### PR TITLE
feat: Add post overview link and update Booru connectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
 				"@biomejs/biome": "1.9.4",
 				"@tailwindcss/typography": "0.5.16",
 				"@tailwindcss/vite": "4.1.8",
+				"@testing-library/jest-dom": "^6.6.3",
+				"@testing-library/react": "^16.3.0",
 				"@types/react": "19.1.6",
 				"@types/react-dom": "19.1.5",
 				"@vitejs/plugin-react": "4.5.0",
@@ -31,12 +33,19 @@
 				"electron": "36.3.2",
 				"electron-builder": "26.0.12",
 				"electron-devtools-installer": "4.0.0",
+				"jsdom": "^26.1.0",
 				"lefthook": "1.11.13",
 				"tailwindcss": "4.1.8",
 				"typescript": "5.8.3",
 				"vite": "6.3.5",
 				"vitest": "3.1.4"
 			}
+		},
+		"node_modules/@adobe/css-tools": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz",
+			"integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
+			"dev": true
 		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.3.0",
@@ -51,6 +60,25 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"dev": true,
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.26.2",
@@ -498,6 +526,116 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+			"integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+			"integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"dependencies": {
+				"@csstools/color-helpers": "^5.0.2",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@develar/schema-utils": {
@@ -2525,6 +2663,92 @@
 				"vite": "^5.2.0 || ^6"
 			}
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+			"integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@testing-library/jest-dom": {
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+			"integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+			"dev": true,
+			"dependencies": {
+				"@adobe/css-tools": "^4.4.0",
+				"aria-query": "^5.0.0",
+				"chalk": "^3.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.6.3",
+				"lodash": "^4.17.21",
+				"redent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/chalk": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+			"dev": true
+		},
+		"node_modules/@testing-library/react": {
+			"version": "16.3.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+			"integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.12.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": "^10.0.0",
+				"@types/react": "^18.0.0 || ^19.0.0",
+				"@types/react-dom": "^18.0.0 || ^19.0.0",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2534,6 +2758,13 @@
 			"engines": {
 				"node": ">= 10"
 			}
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -3166,6 +3397,15 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"license": "Python-2.0"
+		},
+		"node_modules/aria-query": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"dev": true,
+			"dependencies": {
+				"dequal": "^2.0.3"
+			}
 		},
 		"node_modules/assert-plus": {
 			"version": "1.0.0",
@@ -4060,6 +4300,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"dev": true
+		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4073,11 +4319,37 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/cssstyle": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.1.tgz",
+			"integrity": "sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==",
+			"dev": true,
+			"dependencies": {
+				"@asamuzakjp/css-color": "^3.1.2",
+				"rrweb-cssom": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/csstype": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
 			"license": "MIT"
+		},
+		"node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/debug": {
 			"version": "4.4.0",
@@ -4095,6 +4367,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+			"integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+			"dev": true
 		},
 		"node_modules/decode-named-character-reference": {
 			"version": "1.1.0",
@@ -4390,6 +4668,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/dotenv": {
 			"version": "16.4.7",
@@ -4869,6 +5154,18 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+			"integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/env-paths": {
@@ -5675,6 +5972,18 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/html-entities": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -6049,6 +6358,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true
+		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -6182,6 +6497,45 @@
 			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/jsdom": {
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+			"dev": true,
+			"dependencies": {
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^5.1.1",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/jsesc": {
 			"version": "3.1.0",
@@ -6820,6 +7174,16 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"lz-string": "bin/bin.js"
 			}
 		},
 		"node_modules/magic-string": {
@@ -7596,6 +7960,15 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/min-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/minimatch": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
@@ -7886,6 +8259,12 @@
 				"node": "*"
 			}
 		},
+		"node_modules/nwsapi": {
+			"version": "2.2.20",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+			"integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+			"dev": true
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8036,6 +8415,18 @@
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
 			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
 			"license": "MIT"
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"dev": true,
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
 		},
 		"node_modules/path-exists": {
 			"version": "5.0.0",
@@ -8246,6 +8637,41 @@
 			"engines": {
 				"node": "^12.20.0 || >=14"
 			}
+		},
+		"node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/pretty-format/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/proc-log": {
 			"version": "2.0.1",
@@ -8475,6 +8901,19 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/redent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+			"dev": true,
+			"dependencies": {
+				"indent-string": "^4.0.0",
+				"strip-indent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/regenerator-runtime": {
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -8661,6 +9100,12 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"dev": true
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -8704,6 +9149,18 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
 			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
 			"license": "ISC"
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
 		},
 		"node_modules/scheduler": {
 			"version": "0.26.0",
@@ -9135,6 +9592,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/strip-indent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+			"dev": true,
+			"dependencies": {
+				"min-indent": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/style-to-js": {
 			"version": "1.1.16",
 			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
@@ -9178,6 +9647,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true
 		},
 		"node_modules/tailwindcss": {
 			"version": "4.1.8",
@@ -9411,6 +9886,24 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"dev": true,
+			"dependencies": {
+				"tldts-core": "^6.1.86"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"dev": true
+		},
 		"node_modules/tmp": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -9429,6 +9922,30 @@
 			"license": "MIT",
 			"dependencies": {
 				"tmp": "^0.2.0"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"dev": true,
+			"dependencies": {
+				"tldts": "^6.1.32"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/trim-lines": {
@@ -9958,6 +10475,18 @@
 				}
 			}
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -9966,6 +10495,49 @@
 			"license": "MIT",
 			"dependencies": {
 				"defaults": "^1.0.3"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"dev": true,
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"dev": true,
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/which": {
@@ -10109,6 +10681,36 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/ws": {
+			"version": "8.18.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+			"integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/xmlbuilder": {
 			"version": "15.1.1",
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -10118,6 +10720,12 @@
 			"engines": {
 				"node": ">=8.0"
 			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -9,20 +9,13 @@
 	"build": {
 		"appId": "dev.pikdum.ebb",
 		"win": {
-			"publish": [
-				"github"
-			]
+			"publish": ["github"]
 		},
-		"files": [
-			"out/**/*",
-			"!node_modules/"
-		],
+		"files": ["out/**/*", "!node_modules/"],
 		"linux": {
 			"category": "Graphics",
 			"target": "AppImage",
-			"publish": [
-				"github"
-			]
+			"publish": ["github"]
 		}
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,20 @@
 	"build": {
 		"appId": "dev.pikdum.ebb",
 		"win": {
-			"publish": ["github"]
+			"publish": [
+				"github"
+			]
 		},
-		"files": ["out/**/*", "!node_modules/"],
+		"files": [
+			"out/**/*",
+			"!node_modules/"
+		],
 		"linux": {
 			"category": "Graphics",
 			"target": "AppImage",
-			"publish": ["github"]
+			"publish": [
+				"github"
+			]
 		}
 	},
 	"scripts": {
@@ -34,6 +41,8 @@
 		"@biomejs/biome": "1.9.4",
 		"@tailwindcss/typography": "0.5.16",
 		"@tailwindcss/vite": "4.1.8",
+		"@testing-library/jest-dom": "^6.6.3",
+		"@testing-library/react": "^16.3.0",
 		"@types/react": "19.1.6",
 		"@types/react-dom": "19.1.5",
 		"@vitejs/plugin-react": "4.5.0",
@@ -41,6 +50,7 @@
 		"electron": "36.3.2",
 		"electron-builder": "26.0.12",
 		"electron-devtools-installer": "4.0.0",
+		"jsdom": "^26.1.0",
 		"lefthook": "1.11.13",
 		"tailwindcss": "4.1.8",
 		"typescript": "5.8.3",

--- a/renderer/components/PostDetails.test.tsx
+++ b/renderer/components/PostDetails.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { PostDetails } from "./PostDetails";
+import type { BooruPost } from "../lib/booru";
+
+// Mock useAppContext
+vi.mock("../App", () => ({
+	useAppContext: () => ({
+		addTab: vi.fn(),
+	}),
+}));
+
+// Mock useMainContext
+vi.mock("../MainApp", () => ({
+	useMainContext: () => ({
+		query: "",
+		tempQuery: "",
+		setTempQuery: vi.fn(),
+	}),
+}));
+
+const mockPost: BooruPost = {
+	id: "123",
+	tags: ["tag1", "artist:artist1"],
+	fileUrl: "https://example.com/image.jpg",
+	previewUrl: "https://example.com/preview.jpg",
+	sampleUrl: "https://example.com/sample.jpg",
+	postView: "https://example.com/post/123",
+	height: 1000,
+	width: 800,
+	rating: "general",
+	createdAt: new Date().toISOString(),
+	getTagGroups: undefined, // Let's assume no getTagGroups for simplicity in this test
+};
+
+describe("PostDetails", () => {
+	it("renders post overview link correctly", () => {
+		render(<PostDetails post={mockPost} />);
+
+		// Check for the "Post Overview" label
+		expect(screen.getByText("Post Overview")).toBeInTheDocument();
+
+		// Find the link by its text "Link"
+		const linkElement = screen.getByRole("link", { name: "Link" });
+		expect(linkElement).toBeInTheDocument();
+
+		// Verify href attribute
+		expect(linkElement).toHaveAttribute("href", mockPost.postView);
+
+		// Verify target attribute
+		expect(linkElement).toHaveAttribute("target", "_blank");
+
+		// Verify rel attribute
+		expect(linkElement).toHaveAttribute("rel", "noopener noreferrer");
+	});
+
+	it("renders tags correctly when getTagGroups is not defined", () => {
+		render(<PostDetails post={mockPost} />);
+		expect(screen.getByText("tag1")).toBeInTheDocument();
+		expect(screen.getByText("artist:artist1")).toBeInTheDocument();
+	});
+
+	it("renders rating and date correctly", () => {
+		render(<PostDetails post={mockPost} />);
+		expect(screen.getByText(mockPost.rating)).toBeInTheDocument();
+		const date = new Date(mockPost.createdAt);
+		const formattedDate = date.toLocaleDateString("en-US", {
+			year: "numeric",
+			month: "long",
+			day: "numeric",
+		});
+		expect(screen.getByText(formattedDate)).toBeInTheDocument();
+	});
+
+
+	// Test case for when getTagGroups is defined
+	const mockPostWithTagGroups: BooruPost = {
+		...mockPost,
+		id: "456",
+		postView: "https://example.com/post/456",
+		getTagGroups: async () => ({
+			Character: ["char1", "char2"],
+			Artist: ["artist_from_group"],
+		}),
+	};
+
+	it("renders tags correctly when getTagGroups is defined", async () => {
+		render(<PostDetails post={mockPostWithTagGroups} />);
+
+		// Wait for getTagGroups to resolve and tags to render
+		expect(await screen.findByText("char1")).toBeInTheDocument();
+		expect(await screen.findByText("char2")).toBeInTheDocument();
+		expect(await screen.findByText("artist_from_group")).toBeInTheDocument();
+
+		// Ensure original tags are not displayed when getTagGroups is present
+		expect(screen.queryByText("tag1")).not.toBeInTheDocument();
+		expect(screen.queryByText("artist:artist1")).not.toBeInTheDocument();
+	});
+});

--- a/renderer/components/PostDetails.test.tsx
+++ b/renderer/components/PostDetails.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
-import { PostDetails } from "./PostDetails";
+import { describe, expect, it, vi } from "vitest";
 import type { BooruPost } from "../lib/booru";
+import { PostDetails } from "./PostDetails";
 
 // Mock useAppContext
 vi.mock("../App", () => ({
@@ -71,7 +71,6 @@ describe("PostDetails", () => {
 		});
 		expect(screen.getByText(formattedDate)).toBeInTheDocument();
 	});
-
 
 	// Test case for when getTagGroups is defined
 	const mockPostWithTagGroups: BooruPost = {

--- a/renderer/components/PostDetails.tsx
+++ b/renderer/components/PostDetails.tsx
@@ -132,6 +132,19 @@ export const PostDetails = ({ post }: { post: BooruPost }) => {
 						{formatDate(post.createdAt)}
 					</div>
 				</div>
+				<div className="flex flex-wrap justify-center gap-2 items-center">
+					<div className="inline text-black text-xs font-semibold p-1 px-3 rounded-sm bg-gray-200">
+						Post Overview
+					</div>
+					<a
+						href={post.postView}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="bg-blue-500 hover:bg-blue-700 text-white text-xs font-semibold p-1 px-3 rounded-full"
+					>
+						Link
+					</a>
+				</div>
 			</div>
 		</div>
 	);

--- a/renderer/lib/booru/danbooru.test.ts
+++ b/renderer/lib/booru/danbooru.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { Danbooru } from "./danbooru"; // Assuming Danbooru class is exported
+import type { BooruPost } from "./index";
+
+describe("Danbooru Connector", () => {
+	describe("transformPostData", () => {
+		it("should correctly transform raw post data and include postView URL", async () => {
+			const mockRawPosts = [
+				{
+					id: 12345,
+					image_width: 800,
+					image_height: 1200,
+					tag_string: "tag1 tag2 artist:some_artist copyright:some_copyright character:some_character",
+					file_url: "https://danbooru.donmai.us/data/sample/sample-12345.jpg",
+					large_file_url: "https://danbooru.donmai.us/data/sample/sample-12345.jpg",
+					preview_file_url: "https://danbooru.donmai.us/data/preview/preview-12345.jpg",
+					rating: "g",
+					tag_string_general: "tag1 tag2",
+					tag_string_character: "some_character",
+					tag_string_copyright: "some_copyright",
+					tag_string_artist: "some_artist",
+					tag_string_meta: "meta_tag",
+					created_at: "2023-01-15T10:30:00.000Z",
+				},
+				{
+					id: 67890,
+					image_width: 1024,
+					image_height: 768,
+					tag_string: "another_tag solo",
+					file_url: "https://danbooru.donmai.us/data/sample/sample-67890.png",
+					large_file_url: "https://danbooru.donmai.us/data/sample/sample-67890.png",
+					preview_file_url: "https://danbooru.donmai.us/data/preview/preview-67890.jpg",
+					rating: "s",
+					tag_string_general: "another_tag solo",
+					tag_string_character: "",
+					tag_string_copyright: "",
+					tag_string_artist: "",
+					tag_string_meta: "",
+					created_at: "2023-02-20T12:00:00.000Z",
+				},
+			];
+
+			const result = Danbooru.transformPostData(mockRawPosts);
+			expect(result.posts).toHaveLength(2);
+			expect(result.hasNextPage).toBe(true); // Based on current logic that it's true if posts.length > 0
+
+			// Check first post
+			const post1 = result.posts[0];
+			expect(post1.id).toBe("12345");
+			expect(post1.postView).toBe("https://danbooru.donmai.us/posts/12345");
+			expect(post1.fileUrl).toBe(mockRawPosts[0].file_url);
+			expect(post1.previewUrl).toBe(mockRawPosts[0].preview_file_url);
+			expect(post1.sampleUrl).toBe(mockRawPosts[0].large_file_url);
+			expect(post1.tags).toEqual(mockRawPosts[0].tag_string.split(" "));
+			expect(post1.rating).toBe("general"); // transformed from 'g'
+			expect(post1.createdAt).toBe(new Date(mockRawPosts[0].created_at).toISOString());
+			expect(post1.height).toBe(mockRawPosts[0].image_height);
+			expect(post1.width).toBe(mockRawPosts[0].image_width);
+
+			// Check second post
+			const post2 = result.posts[1];
+			expect(post2.id).toBe("67890");
+			expect(post2.postView).toBe("https://danbooru.donmai.us/posts/67890");
+			expect(post2.rating).toBe("sensitive"); // transformed from 's'
+
+			// Test getTagGroups for the first post
+			if (post1.getTagGroups) {
+				const tagGroups = await post1.getTagGroups();
+				expect(tagGroups.Tag).toEqual(["tag1", "tag2"]);
+				expect(tagGroups.Character).toEqual(["some_character"]);
+				expect(tagGroups.Copyright).toEqual(["some_copyright"]);
+				expect(tagGroups.Artist).toEqual(["some_artist"]);
+				expect(tagGroups.Metadata).toEqual(["meta_tag"]);
+			} else {
+				// Should not happen if getTagGroups is implemented as expected
+				throw new Error("getTagGroups not defined on Danbooru post object");
+			}
+		});
+
+		it("should handle empty input", () => {
+			const result = Danbooru.transformPostData([]);
+			expect(result.posts).toHaveLength(0);
+			expect(result.hasNextPage).toBe(false);
+		});
+
+		it("should filter out posts without file_url", () => {
+			const mockRawPostsWithMissingFileUrl = [
+				{
+					id: 111,
+					// ... other fields ...
+					file_url: undefined, // Missing file_url
+					tag_string: "test",
+					created_at: "2023-01-01T00:00:00.000Z",
+					rating: "g",
+				},
+				{
+					id: 222,
+					file_url: "https://danbooru.donmai.us/data/sample/sample-222.jpg",
+					// ... other fields ...
+					tag_string: "test2",
+					created_at: "2023-01-02T00:00:00.000Z",
+					rating: "q",
+				}
+			];
+			// @ts-expect-error testing invalid input
+			const result = Danbooru.transformPostData(mockRawPostsWithMissingFileUrl);
+			expect(result.posts).toHaveLength(1);
+			expect(result.posts[0].id).toBe("222");
+			expect(result.posts[0].postView).toBe("https://danbooru.donmai.us/posts/222");
+		});
+	});
+});

--- a/renderer/lib/booru/danbooru.test.ts
+++ b/renderer/lib/booru/danbooru.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { Danbooru } from "./danbooru"; // Assuming Danbooru class is exported
-import type { BooruPost } from "./index";
 
 describe("Danbooru Connector", () => {
 	describe("transformPostData", () => {
@@ -10,10 +9,13 @@ describe("Danbooru Connector", () => {
 					id: 12345,
 					image_width: 800,
 					image_height: 1200,
-					tag_string: "tag1 tag2 artist:some_artist copyright:some_copyright character:some_character",
+					tag_string:
+						"tag1 tag2 artist:some_artist copyright:some_copyright character:some_character",
 					file_url: "https://danbooru.donmai.us/data/sample/sample-12345.jpg",
-					large_file_url: "https://danbooru.donmai.us/data/sample/sample-12345.jpg",
-					preview_file_url: "https://danbooru.donmai.us/data/preview/preview-12345.jpg",
+					large_file_url:
+						"https://danbooru.donmai.us/data/sample/sample-12345.jpg",
+					preview_file_url:
+						"https://danbooru.donmai.us/data/preview/preview-12345.jpg",
 					rating: "g",
 					tag_string_general: "tag1 tag2",
 					tag_string_character: "some_character",
@@ -28,8 +30,10 @@ describe("Danbooru Connector", () => {
 					image_height: 768,
 					tag_string: "another_tag solo",
 					file_url: "https://danbooru.donmai.us/data/sample/sample-67890.png",
-					large_file_url: "https://danbooru.donmai.us/data/sample/sample-67890.png",
-					preview_file_url: "https://danbooru.donmai.us/data/preview/preview-67890.jpg",
+					large_file_url:
+						"https://danbooru.donmai.us/data/sample/sample-67890.png",
+					preview_file_url:
+						"https://danbooru.donmai.us/data/preview/preview-67890.jpg",
 					rating: "s",
 					tag_string_general: "another_tag solo",
 					tag_string_character: "",
@@ -53,7 +57,9 @@ describe("Danbooru Connector", () => {
 			expect(post1.sampleUrl).toBe(mockRawPosts[0].large_file_url);
 			expect(post1.tags).toEqual(mockRawPosts[0].tag_string.split(" "));
 			expect(post1.rating).toBe("general"); // transformed from 'g'
-			expect(post1.createdAt).toBe(new Date(mockRawPosts[0].created_at).toISOString());
+			expect(post1.createdAt).toBe(
+				new Date(mockRawPosts[0].created_at).toISOString(),
+			);
 			expect(post1.height).toBe(mockRawPosts[0].image_height);
 			expect(post1.width).toBe(mockRawPosts[0].image_width);
 
@@ -100,13 +106,15 @@ describe("Danbooru Connector", () => {
 					tag_string: "test2",
 					created_at: "2023-01-02T00:00:00.000Z",
 					rating: "q",
-				}
+				},
 			];
 			// @ts-expect-error testing invalid input
 			const result = Danbooru.transformPostData(mockRawPostsWithMissingFileUrl);
 			expect(result.posts).toHaveLength(1);
 			expect(result.posts[0].id).toBe("222");
-			expect(result.posts[0].postView).toBe("https://danbooru.donmai.us/posts/222");
+			expect(result.posts[0].postView).toBe(
+				"https://danbooru.donmai.us/posts/222",
+			);
 		});
 	});
 });

--- a/renderer/lib/booru/danbooru.ts
+++ b/renderer/lib/booru/danbooru.ts
@@ -83,6 +83,7 @@ export class Danbooru {
 		return {
 			posts: posts.map((post) => ({
 				id: post.id.toString(),
+				postView: `https://danbooru.donmai.us/posts/${post.id}`,
 				tags: post.tag_string.split(" ") ?? [],
 				fileUrl: post.file_url,
 				previewUrl: post.preview_file_url,

--- a/renderer/lib/booru/e621.test.ts
+++ b/renderer/lib/booru/e621.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { e621 } from "./e621"; // Assuming e621 class is exported
+import type { BooruPost } from "./index";
+
+describe("e621 Connector", () => {
+	describe("transformPostData", () => {
+		it("should correctly transform raw post data and include postView URL", async () => {
+			const mockRawData = {
+				posts: [
+					{
+						id: 78901,
+						file: {
+							width: 1200,
+							height: 900,
+							ext: "png",
+							size: 1024000,
+							md5: "abcdef1234567890",
+							url: "https://static1.e621.net/data/sample/ab/cd/abcdef1234567890.png",
+						},
+						preview: {
+							width: 150,
+							height: 112,
+							url: "https://static1.e621.net/data/preview/ab/cd/abcdef1234567890.jpg",
+						},
+						sample: {
+							has: true,
+							width: 800,
+							height: 600,
+							url: "https://static1.e621.net/data/sample/ab/cd/abcdef1234567890.jpg",
+						},
+						tags: {
+							general: ["tag1", "tag2"],
+							artist: ["artist1"],
+							copyright: ["copy1"],
+							character: ["char1"],
+							species: ["spec1"],
+							invalid: [],
+							meta: ["meta1"],
+							lore: ["lore1"],
+						},
+						rating: "e",
+						created_at: "2023-03-10T14:45:00.000Z",
+					},
+					{
+						id: 11223,
+						file: {
+							width: 800,
+							height: 1000,
+							ext: "jpg",
+							size: 900000,
+							md5: "0987654321fedcba",
+							url: "https://static1.e621.net/data/sample/09/87/0987654321fedcba.jpg",
+						},
+						preview: {
+							width: 120,
+							height: 150,
+							url: "https://static1.e621.net/data/preview/09/87/0987654321fedcba.jpg",
+						},
+						sample: {
+							has: false, // No sample URL
+							width: 0,
+							height: 0,
+							url: null,
+						},
+						tags: {
+							general: ["solo_focus"],
+							artist: ["artist2"],
+							copyright: [],
+							character: [],
+							species: ["spec2"],
+							invalid: [],
+							meta: [],
+							lore: [],
+						},
+						rating: "q",
+						created_at: "2023-04-05T18:00:00.000Z",
+					},
+				],
+			};
+
+			const result = e621.transformPostData(mockRawData);
+			expect(result.posts).toHaveLength(2);
+			expect(result.hasNextPage).toBe(true);
+
+			const post1 = result.posts[0];
+			expect(post1.id).toBe("78901");
+			expect(post1.postView).toBe("https://e621.net/posts/78901");
+			expect(post1.fileUrl).toBe(mockRawData.posts[0].file.url);
+			expect(post1.previewUrl).toBe(mockRawData.posts[0].preview.url);
+			expect(post1.sampleUrl).toBe(mockRawData.posts[0].sample.url);
+			const expectedTags1 = Object.values(mockRawData.posts[0].tags).flat();
+			expect(post1.tags.sort()).toEqual(expectedTags1.sort());
+			expect(post1.rating).toBe("explicit"); // transformed from 'e'
+			expect(post1.createdAt).toBe(new Date(mockRawData.posts[0].created_at).toISOString());
+			expect(post1.height).toBe(mockRawData.posts[0].file.height);
+			expect(post1.width).toBe(mockRawData.posts[0].file.width);
+
+			const post2 = result.posts[1];
+			expect(post2.id).toBe("11223");
+			expect(post2.postView).toBe("https://e621.net/posts/11223");
+			expect(post2.sampleUrl).toBeNull(); // as sample.has is false
+			expect(post2.rating).toBe("questionable"); // transformed from 'q'
+
+			// Test getTagGroups for the first post
+			if (post1.getTagGroups) {
+				const tagGroups = await post1.getTagGroups();
+				expect(tagGroups.Tag).toEqual(mockRawData.posts[0].tags.general);
+				expect(tagGroups.Artist).toEqual(mockRawData.posts[0].tags.artist);
+				expect(tagGroups.Copyright).toEqual(mockRawData.posts[0].tags.copyright);
+				expect(tagGroups.Character).toEqual(mockRawData.posts[0].tags.character);
+				expect(tagGroups.Species).toEqual(mockRawData.posts[0].tags.species);
+				expect(tagGroups.Metadata).toEqual(mockRawData.posts[0].tags.meta);
+				expect(tagGroups.Lore).toEqual(mockRawData.posts[0].tags.lore);
+				expect(tagGroups.Invalid).toBeUndefined(); // As it's empty
+			} else {
+				throw new Error("getTagGroups not defined on e621 post object");
+			}
+		});
+
+		it("should handle empty input (no posts)", () => {
+			const result = e621.transformPostData({ posts: [] });
+			expect(result.posts).toHaveLength(0);
+			expect(result.hasNextPage).toBe(false);
+		});
+
+		it("should handle null or undefined input", () => {
+			// @ts-expect-error testing invalid input
+			const resultNull = e621.transformPostData(null);
+			expect(resultNull.posts).toHaveLength(0);
+			expect(resultNull.hasNextPage).toBe(false);
+
+			// @ts-expect-error testing invalid input
+			const resultUndefined = e621.transformPostData(undefined);
+			expect(resultUndefined.posts).toHaveLength(0);
+			expect(resultUndefined.hasNextPage).toBe(false);
+		});
+
+		it("should filter out posts without file.url", () => {
+			const mockRawDataWithMissingFileUrl = {
+				posts: [
+					// Post that should be filtered out
+					{
+						id: 333,
+						file: { url: undefined, width: 100, height: 100, ext: "jpg", size: 123, md5: "abc" },
+						// Provide other fields like preview, sample, tags, rating, created_at
+						// to ensure the test is robust and doesn't fail due to these missing
+						// if the filtering logic changes or has issues.
+						preview: { url: "preview_url_333", width:10, height:10 },
+						sample: { has: false, url: null, width:0, height:0 },
+						tags: { general: ["test_filter_out"] },
+						rating: "s",
+						created_at: "2023-01-01T00:00:00.000Z"
+					},
+					// Post that should NOT be filtered out
+					{
+						id: 444,
+						file: { url: "https://static1.e621.net/data/sample/ef/gh/efghef12345.jpg", width: 200, height: 200, ext: "jpg", size: 456, md5: "def" },
+						preview: { url: "https://static1.e621.net/data/preview/ef/gh/efghef12345.jpg", width:20, height:20 },
+						sample: { has: true, url: "https://static1.e621.net/data/sample/ef/gh/efghef12345.jpg", width:100, height:100 },
+						tags: { general: ["test_keep"] },
+						rating: "g",
+						created_at: "2023-01-02T00:00:00.000Z"
+					},
+				],
+			};
+			const result = e621.transformPostData(mockRawDataWithMissingFileUrl);
+			expect(result.posts).toHaveLength(1);
+			expect(result.posts[0].id).toBe("444"); // Ensure the correct post is kept
+			expect(result.posts[0].postView).toBe("https://e621.net/posts/444");
+		});
+	});
+});

--- a/renderer/lib/booru/e621.test.ts
+++ b/renderer/lib/booru/e621.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { e621 } from "./e621"; // Assuming e621 class is exported
-import type { BooruPost } from "./index";
 
 describe("e621 Connector", () => {
 	describe("transformPostData", () => {
@@ -91,7 +90,9 @@ describe("e621 Connector", () => {
 			const expectedTags1 = Object.values(mockRawData.posts[0].tags).flat();
 			expect(post1.tags.sort()).toEqual(expectedTags1.sort());
 			expect(post1.rating).toBe("explicit"); // transformed from 'e'
-			expect(post1.createdAt).toBe(new Date(mockRawData.posts[0].created_at).toISOString());
+			expect(post1.createdAt).toBe(
+				new Date(mockRawData.posts[0].created_at).toISOString(),
+			);
 			expect(post1.height).toBe(mockRawData.posts[0].file.height);
 			expect(post1.width).toBe(mockRawData.posts[0].file.width);
 
@@ -106,8 +107,12 @@ describe("e621 Connector", () => {
 				const tagGroups = await post1.getTagGroups();
 				expect(tagGroups.Tag).toEqual(mockRawData.posts[0].tags.general);
 				expect(tagGroups.Artist).toEqual(mockRawData.posts[0].tags.artist);
-				expect(tagGroups.Copyright).toEqual(mockRawData.posts[0].tags.copyright);
-				expect(tagGroups.Character).toEqual(mockRawData.posts[0].tags.character);
+				expect(tagGroups.Copyright).toEqual(
+					mockRawData.posts[0].tags.copyright,
+				);
+				expect(tagGroups.Character).toEqual(
+					mockRawData.posts[0].tags.character,
+				);
 				expect(tagGroups.Species).toEqual(mockRawData.posts[0].tags.species);
 				expect(tagGroups.Metadata).toEqual(mockRawData.posts[0].tags.meta);
 				expect(tagGroups.Lore).toEqual(mockRawData.posts[0].tags.lore);
@@ -141,25 +146,48 @@ describe("e621 Connector", () => {
 					// Post that should be filtered out
 					{
 						id: 333,
-						file: { url: undefined, width: 100, height: 100, ext: "jpg", size: 123, md5: "abc" },
+						file: {
+							url: undefined,
+							width: 100,
+							height: 100,
+							ext: "jpg",
+							size: 123,
+							md5: "abc",
+						},
 						// Provide other fields like preview, sample, tags, rating, created_at
 						// to ensure the test is robust and doesn't fail due to these missing
 						// if the filtering logic changes or has issues.
-						preview: { url: "preview_url_333", width:10, height:10 },
-						sample: { has: false, url: null, width:0, height:0 },
+						preview: { url: "preview_url_333", width: 10, height: 10 },
+						sample: { has: false, url: null, width: 0, height: 0 },
 						tags: { general: ["test_filter_out"] },
 						rating: "s",
-						created_at: "2023-01-01T00:00:00.000Z"
+						created_at: "2023-01-01T00:00:00.000Z",
 					},
 					// Post that should NOT be filtered out
 					{
 						id: 444,
-						file: { url: "https://static1.e621.net/data/sample/ef/gh/efghef12345.jpg", width: 200, height: 200, ext: "jpg", size: 456, md5: "def" },
-						preview: { url: "https://static1.e621.net/data/preview/ef/gh/efghef12345.jpg", width:20, height:20 },
-						sample: { has: true, url: "https://static1.e621.net/data/sample/ef/gh/efghef12345.jpg", width:100, height:100 },
+						file: {
+							url: "https://static1.e621.net/data/sample/ef/gh/efghef12345.jpg",
+							width: 200,
+							height: 200,
+							ext: "jpg",
+							size: 456,
+							md5: "def",
+						},
+						preview: {
+							url: "https://static1.e621.net/data/preview/ef/gh/efghef12345.jpg",
+							width: 20,
+							height: 20,
+						},
+						sample: {
+							has: true,
+							url: "https://static1.e621.net/data/sample/ef/gh/efghef12345.jpg",
+							width: 100,
+							height: 100,
+						},
 						tags: { general: ["test_keep"] },
 						rating: "g",
-						created_at: "2023-01-02T00:00:00.000Z"
+						created_at: "2023-01-02T00:00:00.000Z",
 					},
 				],
 			};

--- a/renderer/lib/booru/e621.ts
+++ b/renderer/lib/booru/e621.ts
@@ -110,6 +110,7 @@ export class e621 {
 		return {
 			posts: posts.map((post) => ({
 				id: post.id.toString(),
+				postView: `https://e621.net/posts/${post.id}`,
 				// combine all tags from all categories into a single array
 				tags: Object.values(post.tags).flat() ?? [],
 				fileUrl: post.file.url,

--- a/renderer/lib/booru/gelbooru.test.ts
+++ b/renderer/lib/booru/gelbooru.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import { Gelbooru } from "./gelbooru"; // Assuming Gelbooru class is exported
+import type { BooruPost } from "./index";
+
+// Mock html-entities
+vi.mock("html-entities", () => ({
+	decode: (str: string) => str, // Simple pass-through mock
+}));
+
+describe("Gelbooru Connector", () => {
+	describe("transformPostData", () => {
+		it("should correctly transform raw post data and include postView URL", async () => {
+			const mockRawData = {
+				post: [
+					{
+						id: 5678,
+						width: 1024,
+						height: 768,
+						tags: "tag_a tag_b character_c artist_d copyright_e meta_f",
+						file_url: "https://img3.gelbooru.com/images/00/01/sample_0001abcdef.jpg",
+						preview_url: "https://img3.gelbooru.com/thumbnails/00/01/thumbnail_0001abcdef.jpg",
+						sample_url: "https://img3.gelbooru.com/samples/00/01/sample_0001abcdef.jpg",
+						rating: "explicit", // Gelbooru uses full names
+						created_at: "Sat Mar 12 10:00:00 +0000 2023", // Example date format
+					},
+					{
+						id: 91011,
+						width: 800,
+						height: 1200,
+						tags: "another_one solo",
+						file_url: "https://img3.gelbooru.com/images/00/02/sample_0002ghijkl.png",
+						preview_url: "https://img3.gelbooru.com/thumbnails/00/02/thumbnail_0002ghijkl.jpg",
+						sample_url: "https://img3.gelbooru.com/samples/00/02/sample_0002ghijkl.jpg",
+						rating: "general",
+						created_at: "Sun Apr 15 14:30:00 +0000 2023",
+					},
+				],
+				"@attributes": { limit: 2, offset: 0, count: 100 }, // Example attributes
+			};
+
+			// Mock fetch for getTagGroups
+			const mockTagData = {
+				tag: [
+					{ name: "tag_a", type: 0, count: 10 },
+					{ name: "tag_b", type: 0, count: 12 },
+					{ name: "character_c", type: 4, count: 5 },
+					{ name: "artist_d", type: 1, count: 8 },
+					{ name: "copyright_e", type: 3, count: 3 },
+					{ name: "meta_f", type: 5, count: 20 },
+				],
+			};
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => mockTagData,
+			} as Response);
+
+
+			const result = Gelbooru.transformPostData(mockRawData);
+			expect(result.posts).toHaveLength(2);
+			expect(result.hasNextPage).toBe(true); // count > limit + offset
+
+			const post1 = result.posts[0];
+			expect(post1.id).toBe("5678");
+			expect(post1.postView).toBe("https://gelbooru.com/index.php?page=post&s=view&id=5678");
+			expect(post1.fileUrl).toBe(mockRawData.post[0].file_url);
+			expect(post1.previewUrl).toBe(mockRawData.post[0].preview_url);
+			expect(post1.sampleUrl).toBe(mockRawData.post[0].sample_url);
+			expect(post1.tags).toEqual(mockRawData.post[0].tags.split(" "));
+			expect(post1.rating).toBe("explicit");
+			expect(post1.createdAt).toBe(new Date(mockRawData.post[0].created_at).toISOString());
+			expect(post1.height).toBe(mockRawData.post[0].height);
+			expect(post1.width).toBe(mockRawData.post[0].width);
+
+			const post2 = result.posts[1];
+			expect(post2.id).toBe("91011");
+			expect(post2.postView).toBe("https://gelbooru.com/index.php?page=post&s=view&id=91011");
+			expect(post2.rating).toBe("general");
+
+			// Test getTagGroups for the first post
+			if (post1.getTagGroups) {
+				const tagGroups = await post1.getTagGroups();
+				expect(tagGroups.Tag).toEqual(["tag_a", "tag_b"]);
+				expect(tagGroups.Character).toEqual(["character_c"]);
+				expect(tagGroups.Artist).toEqual(["artist_d"]);
+				expect(tagGroups.Copyright).toEqual(["copyright_e"]);
+				expect(tagGroups.Metadata).toEqual(["meta_f"]);
+				const expectedTagsParam = mockRawData.post[0].tags.replace(/ /g, "+");
+				const expectedUrl = `https://gelbooru.com/index.php?page=dapi&s=tag&q=index&json=1&orderby=name&order=asc&names=${expectedTagsParam}`;
+				expect(global.fetch).toHaveBeenCalledWith(
+					expect.objectContaining({ href: expectedUrl })
+				);
+			} else {
+				throw new Error("getTagGroups not defined on Gelbooru post object");
+			}
+			vi.restoreAllMocks(); // Restore fetch mock
+		});
+
+		it("should handle empty input (no post array)", () => {
+			// @ts-expect-error testing invalid input
+			const result = Gelbooru.transformPostData({ "@attributes": { limit: 0, offset: 0, count: 0 } });
+			expect(result.posts).toHaveLength(0);
+			expect(result.hasNextPage).toBe(false);
+		});
+
+		it("should handle empty post array", () => {
+			const result = Gelbooru.transformPostData({ post: [], "@attributes": { limit: 0, offset: 0, count: 0 } });
+			expect(result.posts).toHaveLength(0);
+			expect(result.hasNextPage).toBe(false);
+		});
+
+		it("should handle hasNextPage correctly", () => {
+			const validCreatedAt = "Sat Mar 12 10:00:00 +0000 2023";
+			const dataWithNext = { post: [{id:1, file_url:"f",tags:"",created_at:validCreatedAt, rating:"g", width:100, height:100, preview_url:"pu", sample_url:"su"}], "@attributes": { limit: 1, offset: 0, count: 10 } };
+			expect(Gelbooru.transformPostData(dataWithNext).hasNextPage).toBe(true);
+
+			const dataWithoutNext = { post: [{id:1, file_url:"f",tags:"",created_at:validCreatedAt, rating:"g", width:100, height:100, preview_url:"pu", sample_url:"su"}], "@attributes": { limit: 1, offset: 9, count: 10 } };
+			expect(Gelbooru.transformPostData(dataWithoutNext).hasNextPage).toBe(false);
+		});
+	});
+});

--- a/renderer/lib/booru/gelbooru.test.ts
+++ b/renderer/lib/booru/gelbooru.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Gelbooru } from "./gelbooru"; // Assuming Gelbooru class is exported
-import type { BooruPost } from "./index";
 
 // Mock html-entities
 vi.mock("html-entities", () => ({
@@ -17,9 +16,12 @@ describe("Gelbooru Connector", () => {
 						width: 1024,
 						height: 768,
 						tags: "tag_a tag_b character_c artist_d copyright_e meta_f",
-						file_url: "https://img3.gelbooru.com/images/00/01/sample_0001abcdef.jpg",
-						preview_url: "https://img3.gelbooru.com/thumbnails/00/01/thumbnail_0001abcdef.jpg",
-						sample_url: "https://img3.gelbooru.com/samples/00/01/sample_0001abcdef.jpg",
+						file_url:
+							"https://img3.gelbooru.com/images/00/01/sample_0001abcdef.jpg",
+						preview_url:
+							"https://img3.gelbooru.com/thumbnails/00/01/thumbnail_0001abcdef.jpg",
+						sample_url:
+							"https://img3.gelbooru.com/samples/00/01/sample_0001abcdef.jpg",
 						rating: "explicit", // Gelbooru uses full names
 						created_at: "Sat Mar 12 10:00:00 +0000 2023", // Example date format
 					},
@@ -28,9 +30,12 @@ describe("Gelbooru Connector", () => {
 						width: 800,
 						height: 1200,
 						tags: "another_one solo",
-						file_url: "https://img3.gelbooru.com/images/00/02/sample_0002ghijkl.png",
-						preview_url: "https://img3.gelbooru.com/thumbnails/00/02/thumbnail_0002ghijkl.jpg",
-						sample_url: "https://img3.gelbooru.com/samples/00/02/sample_0002ghijkl.jpg",
+						file_url:
+							"https://img3.gelbooru.com/images/00/02/sample_0002ghijkl.png",
+						preview_url:
+							"https://img3.gelbooru.com/thumbnails/00/02/thumbnail_0002ghijkl.jpg",
+						sample_url:
+							"https://img3.gelbooru.com/samples/00/02/sample_0002ghijkl.jpg",
 						rating: "general",
 						created_at: "Sun Apr 15 14:30:00 +0000 2023",
 					},
@@ -54,26 +59,31 @@ describe("Gelbooru Connector", () => {
 				json: async () => mockTagData,
 			} as Response);
 
-
 			const result = Gelbooru.transformPostData(mockRawData);
 			expect(result.posts).toHaveLength(2);
 			expect(result.hasNextPage).toBe(true); // count > limit + offset
 
 			const post1 = result.posts[0];
 			expect(post1.id).toBe("5678");
-			expect(post1.postView).toBe("https://gelbooru.com/index.php?page=post&s=view&id=5678");
+			expect(post1.postView).toBe(
+				"https://gelbooru.com/index.php?page=post&s=view&id=5678",
+			);
 			expect(post1.fileUrl).toBe(mockRawData.post[0].file_url);
 			expect(post1.previewUrl).toBe(mockRawData.post[0].preview_url);
 			expect(post1.sampleUrl).toBe(mockRawData.post[0].sample_url);
 			expect(post1.tags).toEqual(mockRawData.post[0].tags.split(" "));
 			expect(post1.rating).toBe("explicit");
-			expect(post1.createdAt).toBe(new Date(mockRawData.post[0].created_at).toISOString());
+			expect(post1.createdAt).toBe(
+				new Date(mockRawData.post[0].created_at).toISOString(),
+			);
 			expect(post1.height).toBe(mockRawData.post[0].height);
 			expect(post1.width).toBe(mockRawData.post[0].width);
 
 			const post2 = result.posts[1];
 			expect(post2.id).toBe("91011");
-			expect(post2.postView).toBe("https://gelbooru.com/index.php?page=post&s=view&id=91011");
+			expect(post2.postView).toBe(
+				"https://gelbooru.com/index.php?page=post&s=view&id=91011",
+			);
 			expect(post2.rating).toBe("general");
 
 			// Test getTagGroups for the first post
@@ -87,7 +97,7 @@ describe("Gelbooru Connector", () => {
 				const expectedTagsParam = mockRawData.post[0].tags.replace(/ /g, "+");
 				const expectedUrl = `https://gelbooru.com/index.php?page=dapi&s=tag&q=index&json=1&orderby=name&order=asc&names=${expectedTagsParam}`;
 				expect(global.fetch).toHaveBeenCalledWith(
-					expect.objectContaining({ href: expectedUrl })
+					expect.objectContaining({ href: expectedUrl }),
 				);
 			} else {
 				throw new Error("getTagGroups not defined on Gelbooru post object");
@@ -97,24 +107,61 @@ describe("Gelbooru Connector", () => {
 
 		it("should handle empty input (no post array)", () => {
 			// @ts-expect-error testing invalid input
-			const result = Gelbooru.transformPostData({ "@attributes": { limit: 0, offset: 0, count: 0 } });
+			const result = Gelbooru.transformPostData({
+				"@attributes": { limit: 0, offset: 0, count: 0 },
+			});
 			expect(result.posts).toHaveLength(0);
 			expect(result.hasNextPage).toBe(false);
 		});
 
 		it("should handle empty post array", () => {
-			const result = Gelbooru.transformPostData({ post: [], "@attributes": { limit: 0, offset: 0, count: 0 } });
+			const result = Gelbooru.transformPostData({
+				post: [],
+				"@attributes": { limit: 0, offset: 0, count: 0 },
+			});
 			expect(result.posts).toHaveLength(0);
 			expect(result.hasNextPage).toBe(false);
 		});
 
 		it("should handle hasNextPage correctly", () => {
 			const validCreatedAt = "Sat Mar 12 10:00:00 +0000 2023";
-			const dataWithNext = { post: [{id:1, file_url:"f",tags:"",created_at:validCreatedAt, rating:"g", width:100, height:100, preview_url:"pu", sample_url:"su"}], "@attributes": { limit: 1, offset: 0, count: 10 } };
+			const dataWithNext = {
+				post: [
+					{
+						id: 1,
+						file_url: "f",
+						tags: "",
+						created_at: validCreatedAt,
+						rating: "g",
+						width: 100,
+						height: 100,
+						preview_url: "pu",
+						sample_url: "su",
+					},
+				],
+				"@attributes": { limit: 1, offset: 0, count: 10 },
+			};
 			expect(Gelbooru.transformPostData(dataWithNext).hasNextPage).toBe(true);
 
-			const dataWithoutNext = { post: [{id:1, file_url:"f",tags:"",created_at:validCreatedAt, rating:"g", width:100, height:100, preview_url:"pu", sample_url:"su"}], "@attributes": { limit: 1, offset: 9, count: 10 } };
-			expect(Gelbooru.transformPostData(dataWithoutNext).hasNextPage).toBe(false);
+			const dataWithoutNext = {
+				post: [
+					{
+						id: 1,
+						file_url: "f",
+						tags: "",
+						created_at: validCreatedAt,
+						rating: "g",
+						width: 100,
+						height: 100,
+						preview_url: "pu",
+						sample_url: "su",
+					},
+				],
+				"@attributes": { limit: 1, offset: 9, count: 10 },
+			};
+			expect(Gelbooru.transformPostData(dataWithoutNext).hasNextPage).toBe(
+				false,
+			);
 		});
 	});
 });

--- a/renderer/lib/booru/gelbooru.ts
+++ b/renderer/lib/booru/gelbooru.ts
@@ -92,6 +92,7 @@ export class Gelbooru {
 			posts:
 				data?.post?.map((p: GelbooruPost) => ({
 					id: p.id.toString(),
+					postView: `https://gelbooru.com/index.php?page=post&s=view&id=${p.id}`,
 					tags: p.tags.split(" ") ?? [],
 					fileUrl: p.file_url,
 					previewUrl: p.preview_url,

--- a/renderer/lib/booru/index.ts
+++ b/renderer/lib/booru/index.ts
@@ -11,6 +11,7 @@ export type BooruPost = {
 	fileUrl: string;
 	previewUrl: string;
 	sampleUrl: string | null;
+	postView: string;
 	height: number;
 	width: number;
 	rating: string;

--- a/renderer/lib/booru/rule34.test.ts
+++ b/renderer/lib/booru/rule34.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { Rule34 } from "./rule34"; // Assuming Rule34 class is exported
+import type { BooruPost } from "./index";
+
+// Mock html-entities, as Rule34's transformTagData uses decode
+vi.mock("html-entities", () => ({
+	decode: (str: string) => str, // Simple pass-through mock
+}));
+
+describe("Rule34 Connector", () => {
+	describe("transformPostData", () => {
+		it("should correctly transform raw post data and include postView URL", () => {
+			const mockRawPosts = [
+				{
+					id: 121314,
+					width: 1100,
+					height: 850,
+					tags: "tag_x tag_y character_z artist_a copyright_b",
+					file_url: "https://api.rule34.xxx/images/1213/sample_abcdef.jpeg",
+					preview_url: "https://api.rule34.xxx/thumbnails/1213/thumbnail_abcdef.jpeg",
+					sample_url: "https://api.rule34.xxx/samples/1213/sample_abcdef.jpeg",
+					rating: "explicit", // Rule34 seems to store full names or mixed types
+					change: 1678886400, // Unix timestamp (seconds)
+				},
+				{
+					id: 151617,
+					width: 700,
+					height: 1000,
+					tags: "another_tag solo animated",
+					file_url: "https://api.rule34.xxx/images/1516/sample_ghijkl.gif",
+					preview_url: "https://api.rule34.xxx/thumbnails/1516/thumbnail_ghijkl.jpeg", // Preview might be jpeg
+					sample_url: "https://api.rule34.xxx/samples/1516/sample_ghijkl.gif", // Sample is gif
+					rating: "questionable",
+					change: 1678972800,
+				},
+			];
+
+			const result = Rule34.transformPostData(mockRawPosts);
+			expect(result.posts).toHaveLength(2);
+			expect(result.hasNextPage).toBe(true); // Based on current logic
+
+			const post1 = result.posts[0];
+			expect(post1.id).toBe("121314");
+			expect(post1.postView).toBe("https://rule34.xxx/index.php?page=post&s=view&id=121314");
+			expect(post1.fileUrl).toBe(mockRawPosts[0].file_url);
+			expect(post1.previewUrl).toBe(mockRawPosts[0].preview_url);
+			expect(post1.sampleUrl).toBe(mockRawPosts[0].sample_url); // Not a gif
+			expect(post1.tags).toEqual(mockRawPosts[0].tags.split(" "));
+			expect(post1.rating).toBe("explicit");
+			// Multiply by 1000 for JS timestamp (milliseconds)
+			expect(post1.createdAt).toBe(new Date(mockRawPosts[0].change * 1000).toISOString());
+			expect(post1.height).toBe(mockRawPosts[0].height);
+			expect(post1.width).toBe(mockRawPosts[0].width);
+
+			const post2 = result.posts[1];
+			expect(post2.id).toBe("151617");
+			expect(post2.postView).toBe("https://rule34.xxx/index.php?page=post&s=view&id=151617");
+			// Special handling for GIF samples in Rule34 connector
+			expect(post2.sampleUrl).toBe(mockRawPosts[1].preview_url);
+			expect(post2.rating).toBe("questionable");
+
+			// Rule34 transformPostData does not currently implement getTagGroups
+			expect(post1.getTagGroups).toBeUndefined();
+		});
+
+		it("should handle empty input", () => {
+			const result = Rule34.transformPostData([]);
+			expect(result.posts).toHaveLength(0);
+			expect(result.hasNextPage).toBe(false);
+		});
+
+		it("should handle null or undefined input", () => {
+			// @ts-expect-error testing invalid input
+			const resultNull = Rule34.transformPostData(null);
+			expect(resultNull.posts).toHaveLength(0);
+			expect(resultNull.hasNextPage).toBe(false);
+
+			// @ts-expect-error testing invalid input
+			const resultUndefined = Rule34.transformPostData(undefined);
+			expect(resultUndefined.posts).toHaveLength(0);
+			expect(resultUndefined.hasNextPage).toBe(false);
+		});
+
+		it("should use preview_url for sample_url if sample_url ends with .gif", () => {
+			const mockRawGifPost = [
+				{
+					id: 777,
+					file_url: "file.gif",
+					preview_url: "preview.jpg",
+					sample_url: "sample.gif", // GIF sample
+					tags: "animated",
+					rating: "general",
+					change: 1670000000,
+					width: 100,
+					height: 100,
+				},
+			];
+			const result = Rule34.transformPostData(mockRawGifPost);
+			expect(result.posts[0].sampleUrl).toBe(mockRawGifPost[0].preview_url);
+			expect(result.posts[0].postView).toBe("https://rule34.xxx/index.php?page=post&s=view&id=777");
+		});
+	});
+});

--- a/renderer/lib/booru/rule34.test.ts
+++ b/renderer/lib/booru/rule34.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Rule34 } from "./rule34"; // Assuming Rule34 class is exported
-import type { BooruPost } from "./index";
 
 // Mock html-entities, as Rule34's transformTagData uses decode
 vi.mock("html-entities", () => ({
@@ -17,7 +16,8 @@ describe("Rule34 Connector", () => {
 					height: 850,
 					tags: "tag_x tag_y character_z artist_a copyright_b",
 					file_url: "https://api.rule34.xxx/images/1213/sample_abcdef.jpeg",
-					preview_url: "https://api.rule34.xxx/thumbnails/1213/thumbnail_abcdef.jpeg",
+					preview_url:
+						"https://api.rule34.xxx/thumbnails/1213/thumbnail_abcdef.jpeg",
 					sample_url: "https://api.rule34.xxx/samples/1213/sample_abcdef.jpeg",
 					rating: "explicit", // Rule34 seems to store full names or mixed types
 					change: 1678886400, // Unix timestamp (seconds)
@@ -28,7 +28,8 @@ describe("Rule34 Connector", () => {
 					height: 1000,
 					tags: "another_tag solo animated",
 					file_url: "https://api.rule34.xxx/images/1516/sample_ghijkl.gif",
-					preview_url: "https://api.rule34.xxx/thumbnails/1516/thumbnail_ghijkl.jpeg", // Preview might be jpeg
+					preview_url:
+						"https://api.rule34.xxx/thumbnails/1516/thumbnail_ghijkl.jpeg", // Preview might be jpeg
 					sample_url: "https://api.rule34.xxx/samples/1516/sample_ghijkl.gif", // Sample is gif
 					rating: "questionable",
 					change: 1678972800,
@@ -41,20 +42,26 @@ describe("Rule34 Connector", () => {
 
 			const post1 = result.posts[0];
 			expect(post1.id).toBe("121314");
-			expect(post1.postView).toBe("https://rule34.xxx/index.php?page=post&s=view&id=121314");
+			expect(post1.postView).toBe(
+				"https://rule34.xxx/index.php?page=post&s=view&id=121314",
+			);
 			expect(post1.fileUrl).toBe(mockRawPosts[0].file_url);
 			expect(post1.previewUrl).toBe(mockRawPosts[0].preview_url);
 			expect(post1.sampleUrl).toBe(mockRawPosts[0].sample_url); // Not a gif
 			expect(post1.tags).toEqual(mockRawPosts[0].tags.split(" "));
 			expect(post1.rating).toBe("explicit");
 			// Multiply by 1000 for JS timestamp (milliseconds)
-			expect(post1.createdAt).toBe(new Date(mockRawPosts[0].change * 1000).toISOString());
+			expect(post1.createdAt).toBe(
+				new Date(mockRawPosts[0].change * 1000).toISOString(),
+			);
 			expect(post1.height).toBe(mockRawPosts[0].height);
 			expect(post1.width).toBe(mockRawPosts[0].width);
 
 			const post2 = result.posts[1];
 			expect(post2.id).toBe("151617");
-			expect(post2.postView).toBe("https://rule34.xxx/index.php?page=post&s=view&id=151617");
+			expect(post2.postView).toBe(
+				"https://rule34.xxx/index.php?page=post&s=view&id=151617",
+			);
 			// Special handling for GIF samples in Rule34 connector
 			expect(post2.sampleUrl).toBe(mockRawPosts[1].preview_url);
 			expect(post2.rating).toBe("questionable");
@@ -97,7 +104,9 @@ describe("Rule34 Connector", () => {
 			];
 			const result = Rule34.transformPostData(mockRawGifPost);
 			expect(result.posts[0].sampleUrl).toBe(mockRawGifPost[0].preview_url);
-			expect(result.posts[0].postView).toBe("https://rule34.xxx/index.php?page=post&s=view&id=777");
+			expect(result.posts[0].postView).toBe(
+				"https://rule34.xxx/index.php?page=post&s=view&id=777",
+			);
 		});
 	});
 });

--- a/renderer/lib/booru/rule34.ts
+++ b/renderer/lib/booru/rule34.ts
@@ -69,6 +69,7 @@ export class Rule34 {
 			posts:
 				data?.map((p: Rule34Post) => ({
 					id: p.id.toString(),
+					postView: `https://rule34.xxx/index.php?page=post&s=view&id=${p.id}`,
 					tags: p.tags.split(" ") ?? [],
 					fileUrl: p.file_url,
 					previewUrl: p.preview_url,
@@ -81,7 +82,7 @@ export class Rule34 {
 					rating: p.rating,
 					createdAt: new Date(p.change * 1000).toISOString(),
 				})) || [],
-			hasNextPage: data.length > 0,
+			hasNextPage: data?.length > 0,
 		};
 	};
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react({
+    babel: {
+      // Your Babel configuration here
+      plugins: ['babel-plugin-react-compiler'],
+    }
+  })],
+  test: {
+    environment: 'jsdom',
+    globals: true, // Optional: to use Vitest globals like describe, it, expect without importing them
+    setupFiles: './vitest.setup.ts', // Optional: if you need setup files
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,17 +1,19 @@
-import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react({
-    babel: {
-      // Your Babel configuration here
-      plugins: ['babel-plugin-react-compiler'],
-    }
-  })],
-  test: {
-    environment: 'jsdom',
-    globals: true, // Optional: to use Vitest globals like describe, it, expect without importing them
-    setupFiles: './vitest.setup.ts', // Optional: if you need setup files
-  },
+	plugins: [
+		react({
+			babel: {
+				// Your Babel configuration here
+				plugins: ["babel-plugin-react-compiler"],
+			},
+		}),
+	],
+	test: {
+		environment: "jsdom",
+		globals: true, // Optional: to use Vitest globals like describe, it, expect without importing them
+		setupFiles: "./vitest.setup.ts", // Optional: if you need setup files
+	},
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
This commit introduces a new link in the PostDetails component that directs users to the post's overview page on the respective Booru site.

Changes include:
- Added a `postView` field to the `BooruPost` interface.
- Updated all Booru connectors (Danbooru, e621, Gelbooru, Rule34) to fetch and populate the `postView` URL.
- Modified `PostDetails.tsx` to display the "Post Overview" link, which opens in a new tab.
- Added comprehensive unit tests for the new link in `PostDetails.tsx` to verify rendering and functionality.
- Added and updated unit tests for all Booru connectors to ensure the `postView` URL is correctly fetched and processed.